### PR TITLE
Add keyboard support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +83,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide 0.7.1",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,10 +109,22 @@ version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470fbd40e959c961f16841fbf96edbbdcff766ead89a1ae2b53d22852be20998"
 dependencies = [
- "funty",
- "radium",
+ "funty 1.2.0",
+ "radium 0.6.2",
  "tap",
- "wyz",
+ "wyz 0.2.0",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty 2.0.0",
+ "radium 0.7.0",
+ "tap",
+ "wyz 0.5.1",
 ]
 
 [[package]]
@@ -223,8 +259,10 @@ version = "0.4.1"
 dependencies = [
  "doomgeneric",
  "env_logger 0.9.0",
+ "evdev 0.12.1",
  "fxhash",
  "image 0.23.14",
+ "inotify",
  "libremarkable",
  "log",
  "mimalloc",
@@ -289,9 +327,22 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa286e4837bcc689c362ac54f4c036758d625a50b3784b548d946da506d48446"
 dependencies = [
- "bitvec",
+ "bitvec 0.21.2",
  "libc",
  "nix",
+]
+
+[[package]]
+name = "evdev"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bed59fcc8cfd6b190814a509018388462d3b203cf6dd10db5c00087e72a83f3"
+dependencies = [
+ "bitvec 1.0.1",
+ "cfg-if",
+ "libc",
+ "nix",
+ "thiserror",
 ]
 
 [[package]]
@@ -311,6 +362,18 @@ name = "funty"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "fxhash"
@@ -340,6 +403,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
@@ -428,6 +497,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags",
+ "futures-core",
+ "inotify-sys",
+ "libc",
+ "tokio",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ioctl-gen"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,9 +559,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.104"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -492,7 +583,7 @@ dependencies = [
  "cgmath",
  "env_logger 0.7.1",
  "epoll",
- "evdev",
+ "evdev 0.11.1",
  "fxhash",
  "hlua",
  "image 0.21.3",
@@ -595,6 +686,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
 name = "nix"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,9 +760,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eafd0b45c5537c3ba526f79d3e75120036502bebacbb3f3220914067ce39dbf2"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
 ]
 
 [[package]]
@@ -729,6 +840,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,6 +862,12 @@ checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pkg-config"
@@ -783,6 +909,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,7 +929,16 @@ version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 0.4.30",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+dependencies = [
+ "proc-macro2 1.0.76",
 ]
 
 [[package]]
@@ -802,6 +946,12 @@ name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -974,6 +1124,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,6 +1159,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "stb_truetype"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,9 +1192,20 @@ version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
  "unicode-xid",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+dependencies = [
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1044,6 +1221,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+dependencies = [
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1070,10 +1267,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+dependencies = [
+ "backtrace",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "weezl"
@@ -1113,10 +1336,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
 name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ env_logger = "0.9"
 #core_simd = { git = "https://github.com/rust-lang/portable-simd.git", rev = "721164247cd609d04dc8f0bb2483bde83f2a7fd6" }
 # TODO: Bump to 0.9 once libremarkable has updated dependencies
 zstd = "0.5"
+inotify = "0.10"
+evdev = "0.12"
 
 [profile.release]
 # Improves performance significantly

--- a/src/evdev_keyboard.rs
+++ b/src/evdev_keyboard.rs
@@ -1,0 +1,271 @@
+use std::{path::Path, sync::mpsc::Sender};
+
+use doomgeneric::input::KeyData;
+use evdev::Key;
+
+const DEV_INPUT_DIR: &str = "/dev/input";
+
+pub fn init(keydata_tx: Sender<KeyData>) {
+    scan_for_existing_keyboards(&keydata_tx);
+    spawn_keyboard_watcher(keydata_tx);
+}
+
+fn scan_for_existing_keyboards(keydata_tx: &Sender<KeyData>) {
+    // Find existing unknown evdev devices in /dev/input
+    for entry in std::fs::read_dir(DEV_INPUT_DIR).expect("Listing files of input devices dir") {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+        let filename = entry.file_name().to_str().unwrap().to_owned();
+        let path = Path::new(DEV_INPUT_DIR).join(&filename);
+        if path.is_dir()
+            || !filename.starts_with("event")
+            || libremarkable::input::scan::SCANNED.gpio_path == path
+            || libremarkable::input::scan::SCANNED.wacom_path == path
+            || libremarkable::input::scan::SCANNED.multitouch_path == path
+        {
+            continue; // Skip directories or known input devices (gpio, mt, wacom)
+        }
+        info!("Existing evdev device detected: {path:?}");
+        spawn_evdev_keyboard(path, keydata_tx.clone());
+    }
+}
+
+fn spawn_keyboard_watcher(keydata_tx: Sender<KeyData>) {
+    // Listen for new devices in /dev/input to allow hotplugging keyboards
+    std::thread::spawn(move || {
+        let mut inotify = match inotify::Inotify::init() {
+            Ok(inotify) => {
+                if let Err(err) = inotify
+                    .watches()
+                    .add(DEV_INPUT_DIR, inotify::WatchMask::CREATE)
+                {
+                    error!("Could initialize inotify, however adding a watch for new files in {DEV_INPUT_DIR:?} failed: {err:?}");
+                    return;
+                }
+                inotify
+            }
+            Err(err) => {
+                error!("Could not initialize inotify: {err:?}");
+                return;
+            }
+        };
+
+        let mut inotify_buffer = [0u8; 4096];
+        loop {
+            let inotify_events = match inotify.read_events_blocking(&mut inotify_buffer) {
+                Ok(events) => events,
+                Err(err) => {
+                    error!("Encountered an issue while reading inotify events! Keyboard hotplugging will not work anymore! {:?}", err);
+                    return;
+                }
+            };
+
+            for event in inotify_events {
+                if !event.mask.contains(inotify::EventMask::CREATE)
+                    || event.mask.contains(inotify::EventMask::ISDIR)
+                {
+                    continue; // Make sure this is a new file being created
+                }
+
+                let filename = event.name.unwrap().to_str().unwrap();
+                if !filename.starts_with("event") {
+                    continue; // Ignore things like "touchscreen0", "mouse0", etc.
+                }
+                let path = Path::new(DEV_INPUT_DIR).join(filename);
+                info!("New evdev device detected: {path:?}");
+                spawn_evdev_keyboard(path, keydata_tx.clone());
+            }
+        }
+    });
+}
+
+// Check if device is a keyboard, spawn new thread and listen for keystrokes and send them to keydata_tx
+fn spawn_evdev_keyboard(path: impl AsRef<Path>, keydata_tx: std::sync::mpsc::Sender<KeyData>) {
+    // Check if this device is a valid keyboard
+    let mut device = match evdev::Device::open(&path) {
+        Ok(device) => device,
+        Err(err) => {
+            error!("Failed opening evdev device {:?}! {:?}", path.as_ref(), err);
+            return;
+        }
+    };
+    if !device.supported_events().contains(evdev::EventType::KEY)
+        || [
+            evdev::Key::KEY_Q,
+            evdev::Key::KEY_W,
+            evdev::Key::KEY_E,
+            evdev::Key::KEY_R,
+            evdev::Key::KEY_T,
+            evdev::Key::KEY_Y,
+        ]
+        .iter()
+        .any(|key| {
+            !device
+                .supported_keys()
+                .map(|keys| keys.contains(*key))
+                .unwrap_or(false)
+        })
+    {
+        info!("The evdev device {:?} is not a keyboard.", path.as_ref());
+        return;
+    }
+
+    let path = path.as_ref().to_path_buf();
+    // Listen for keys in new thread
+    std::thread::spawn(move || {
+        let name = device.name().unwrap().to_owned();
+        info!("Keyboard at {path:?} detected: {name}");
+
+        loop {
+            let evs: Vec<evdev::InputEvent> = match device.fetch_events() {
+                Ok(evs) => evs,
+                Err(err) => {
+                    debug!("Lost connection to keyboard {name} ({path:?}). It likely got disconnected. Error: {err}");
+                    info!("Keyboard disconnected: {name}");
+                    return;
+                }
+            }.collect();
+
+            for ev in evs {
+                if let evdev::InputEventKind::Key(key) = ev.kind() {
+                    if ev.value() != 0 && ev.value() != 1 {
+                        continue; // Ignore key being held (value == 2) and other potential values.
+                    }
+
+                    if let Ok((keycode, scancodes)) = device.get_scancode_by_index(key.0) {
+                        debug!(
+                            "{} ({:?}, keycode: {keycode}, scancodes: {scancodes:?}) => {}",
+                            key.0,
+                            key,
+                            ev.value()
+                        );
+                    } else {
+                        debug!("{} ({:?}) => {}", key.0, key, ev.value());
+                    }
+
+                    if let Some(doom_key_code) = map_evdev_key_to_doom(key) {
+                        keydata_tx
+                            .send(KeyData {
+                                key: doom_key_code,
+                                pressed: ev.value() == 1,
+                            })
+                            .ok();
+                    }
+                }
+            }
+        }
+    });
+}
+
+fn map_evdev_key_to_doom(key: Key) -> Option<u8> {
+    // https://github.com/ozkl/doomgeneric/blob/613f870b6fa83ede448a247de5a2571092fa729d/doomgeneric/doomkeys.h
+    Some(match key {
+        Key::KEY_A => 'a' as u8,
+        Key::KEY_B => 'b' as u8,
+        Key::KEY_C => 'c' as u8,
+        Key::KEY_D => 'd' as u8,
+        Key::KEY_E => 'e' as u8,
+        Key::KEY_F => 'f' as u8,
+        Key::KEY_G => 'g' as u8,
+        Key::KEY_H => 'h' as u8,
+        Key::KEY_I => 'i' as u8,
+        Key::KEY_J => 'j' as u8,
+        Key::KEY_K => 'k' as u8,
+        Key::KEY_L => 'l' as u8,
+        Key::KEY_M => 'm' as u8,
+        Key::KEY_N => 'n' as u8,
+        Key::KEY_O => 'o' as u8,
+        Key::KEY_P => 'p' as u8,
+        Key::KEY_Q => 'q' as u8,
+        Key::KEY_R => 'r' as u8,
+        Key::KEY_S => 's' as u8,
+        Key::KEY_T => 't' as u8,
+        Key::KEY_U => 'u' as u8,
+        Key::KEY_V => 'v' as u8,
+        Key::KEY_W => 'w' as u8,
+        Key::KEY_X => 'x' as u8,
+        Key::KEY_Y => 'y' as u8,
+        Key::KEY_Z => 'z' as u8,
+        Key::KEY_0 => '0' as u8,
+        Key::KEY_1 => '1' as u8,
+        Key::KEY_2 => '2' as u8,
+        Key::KEY_3 => '3' as u8,
+        Key::KEY_4 => '4' as u8,
+        Key::KEY_5 => '5' as u8,
+        Key::KEY_6 => '6' as u8,
+        Key::KEY_7 => '7' as u8,
+        Key::KEY_8 => '8' as u8,
+        Key::KEY_9 => '9' as u8,
+
+        Key::KEY_RIGHT => 0xae,
+        Key::KEY_LEFT => 0xac,
+        Key::KEY_UP => 0xad,
+        Key::KEY_DOWN => 0xaf,
+        Key::KEY_DOT => 0xa0,   // Strafe left
+        Key::KEY_COMMA => 0xa1, // Strafe right
+        // USE
+        // FIRE
+        Key::KEY_ESC => 27,
+        Key::KEY_ENTER => 13,
+        Key::KEY_TAB => 9,
+        Key::KEY_F1 => 0x80 + 0x3b,
+        Key::KEY_F2 => 0x80 + 0x3c,
+        Key::KEY_F3 => 0x80 + 0x3d,
+        Key::KEY_F4 => 0x80 + 0x3e,
+        Key::KEY_F5 => 0x80 + 0x3f,
+        Key::KEY_F6 => 0x80 + 0x40,
+        Key::KEY_F7 => 0x80 + 0x41,
+        Key::KEY_F8 => 0x80 + 0x42,
+        Key::KEY_F9 => 0x80 + 0x43,
+        Key::KEY_F10 => 0x80 + 0x44,
+        Key::KEY_F11 => 0x80 + 0x57,
+        Key::KEY_F12 => 0x80 + 0x58,
+
+        Key::KEY_BACKSPACE => 0x7f,
+        Key::KEY_PAUSE => 0xff,
+
+        Key::KEY_EQUAL => 0x3d,
+        Key::KEY_MINUS => 0x2d,
+
+        Key::KEY_LEFTSHIFT => 0x80 + 0x36, // Does this have a different key for doom?
+        Key::KEY_RIGHTSHIFT => 0x80 + 0x36,
+        Key::KEY_LEFTCTRL => 0x80 + 0x1d, // Does this have a different key for doom?
+        Key::KEY_RIGHTCTRL => 0x80 + 0x1d,
+        Key::KEY_LEFTALT => 0x80 + 0x38u8,
+        Key::KEY_RIGHTALT => 0x80 + 0x38,
+
+        Key::KEY_CAPSLOCK => 0x80 + 0x3a,
+        Key::KEY_NUMLOCK => 0x80 + 0x45,
+        Key::KEY_SCROLLLOCK => 0x80 + 0x46,
+        Key::KEY_PRINT => 0x80 + 0x59, // Is Print == PRINTSCR?
+
+        Key::KEY_HOME => 0x80 + 0x47,
+        Key::KEY_END => 0x80 + 0x4f,
+        Key::KEY_PAGEUP => 0x80 + 0x49,
+        Key::KEY_PAGEDOWN => 0x80 + 0x51,
+        Key::KEY_INSERT => 0x80 + 0x52,
+        Key::KEY_DELETE => 0x80 + 0x53,
+
+        Key::KEY_KP0 => 0,
+        Key::KEY_KP1 => return map_evdev_key_to_doom(Key::KEY_END),
+        Key::KEY_KP2 => return map_evdev_key_to_doom(Key::KEY_DOWN),
+        Key::KEY_KP3 => return map_evdev_key_to_doom(Key::KEY_PAGEDOWN),
+        Key::KEY_KP4 => return map_evdev_key_to_doom(Key::KEY_LEFT),
+        Key::KEY_KP5 => '5' as u8,
+        Key::KEY_KP6 => return map_evdev_key_to_doom(Key::KEY_RIGHT),
+        Key::KEY_KP7 => return map_evdev_key_to_doom(Key::KEY_HOME),
+        Key::KEY_KP8 => return map_evdev_key_to_doom(Key::KEY_UP),
+        Key::KEY_KP9 => return map_evdev_key_to_doom(Key::KEY_PAGEUP),
+
+        Key::KEY_KPSLASH => '/' as u8,
+        Key::KEY_KPPLUS => '+' as u8,
+        Key::KEY_KPMINUS => '-' as u8,
+        Key::KEY_KPASTERISK => '*' as u8,
+        Key::KEY_KPDOT => 0,
+        Key::KEY_KPENTER => return map_evdev_key_to_doom(Key::KEY_ENTER),
+
+        _ => return None,
+    })
+}

--- a/src/evdev_keyboard.rs
+++ b/src/evdev_keyboard.rs
@@ -27,7 +27,7 @@ fn scan_for_existing_keyboards(keydata_tx: &Sender<KeyData>) {
         {
             continue; // Skip directories or known input devices (gpio, mt, wacom)
         }
-        info!("Existing evdev device detected: {path:?}");
+        debug!("Existing evdev device detected: {path:?}");
         spawn_evdev_keyboard(path, keydata_tx.clone());
     }
 }
@@ -74,7 +74,7 @@ fn spawn_keyboard_watcher(keydata_tx: Sender<KeyData>) {
                     continue; // Ignore things like "touchscreen0", "mouse0", etc.
                 }
                 let path = Path::new(DEV_INPUT_DIR).join(filename);
-                info!("New evdev device detected: {path:?}");
+                debug!("New evdev device detected: {path:?}");
                 spawn_evdev_keyboard(path, keydata_tx.clone());
             }
         }
@@ -152,6 +152,8 @@ fn spawn_evdev_keyboard(path: impl AsRef<Path>, keydata_tx: std::sync::mpsc::Sen
                                 pressed: ev.value() == 1,
                             })
                             .ok();
+                    } else {
+                        debug!("No mapping for key found. Last keypress is not forwarded to game.")
                     }
                 }
             }

--- a/src/evdev_keyboard.rs
+++ b/src/evdev_keyboard.rs
@@ -203,10 +203,10 @@ fn map_evdev_key_to_doom(key: Key) -> Option<u8> {
         Key::KEY_LEFT => 0xac,
         Key::KEY_UP => 0xad,
         Key::KEY_DOWN => 0xaf,
-        Key::KEY_DOT => 0xa0,   // Strafe left
-        Key::KEY_COMMA => 0xa1, // Strafe right
-        // USE
-        // FIRE
+        Key::KEY_DOT => 0xa0,      // Strafe left
+        Key::KEY_COMMA => 0xa1,    // Strafe right
+        Key::KEY_SPACE => 0xa2,    // Use
+        Key::KEY_LEFTCTRL => 0xa3, // Fire... i think
         Key::KEY_ESC => 27,
         Key::KEY_ENTER => 13,
         Key::KEY_TAB => 9,
@@ -231,7 +231,6 @@ fn map_evdev_key_to_doom(key: Key) -> Option<u8> {
 
         Key::KEY_LEFTSHIFT => 0x80 + 0x36, // Does this have a different key for doom?
         Key::KEY_RIGHTSHIFT => 0x80 + 0x36,
-        Key::KEY_LEFTCTRL => 0x80 + 0x1d, // Does this have a different key for doom?
         Key::KEY_RIGHTCTRL => 0x80 + 0x1d,
         Key::KEY_LEFTALT => 0x80 + 0x38u8,
         Key::KEY_RIGHTALT => 0x80 + 0x38,

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 mod blue_noise_dither;
+mod evdev_keyboard;
 mod layout;
 
 const SCALE_FACTOR: usize = 2;
@@ -275,6 +276,7 @@ fn main() {
     });
 
     let (keydata_tx, keydata_rx) = std::sync::mpsc::channel::<KeyData>();
+    evdev_keyboard::init(keydata_tx.clone());
 
     std::thread::spawn(move || {
         let mut layout_manager = layout::LayoutManager::new(&mut FB.lock().unwrap());


### PR DESCRIPTION
Part 1 of solving #2 

@Eeems could you test out whether this works on the rM 1? I could test adding and removing keyboards, but broke my flimsy, only Micro-USB-OTG adapter before I could test the new mappings I added:

https://github.com/LinusCDE/doomarkable/blob/f59178caadec880a2e0e4fd572f0a1c3bd5d9b05/src/evdev_keyboard.rs#L162-L270

Mappings are based on [doomkeys.h](https://github.com/ozkl/doomgeneric/blob/613f870b6fa83ede448a247de5a2571092fa729d/doomgeneric/doomkeys.h), with some guesswork based on [this wiki article](https://en.wikibooks.org/wiki/Doom/Controls).

I do not have a folio, and plugging a USB-C-OTG Adapter in didn't make the keyboard appear for me like it did on the rM 1.