### PR TITLE
Add fullscreen feature and pixel formatting fix

### DIFF
--- a/src/layout/confirmfullscreen.rs
+++ b/src/layout/confirmfullscreen.rs
@@ -1,0 +1,61 @@
+use super::{ButtonAction, Element, Layout, LayoutId};
+use libremarkable::framebuffer::common;
+
+pub fn create() -> Layout {
+    let buttons = vec![
+        Element::Text {
+            rect: common::mxcfb_rect {
+                left: 0,
+                top: 1400 - 300 - 10 - 10,
+                width: common::DISPLAYWIDTH as u32,
+                height: 100,
+            },
+            text: "Go Fullscreen?",
+            size: 100.0,
+        },
+        Element::Text {
+            rect: common::mxcfb_rect {
+                left: 0,
+                top: 1400 - 300 - 10 - 10 + 100,
+                width: common::DISPLAYWIDTH as u32,
+                height: 100,
+            },
+            text: "You'll need to attach a physical keyboard to play!",
+            size: 50.0,
+        },
+        Element::Text {
+            rect: common::mxcfb_rect {
+                left: 0,
+                top: 1400 - 300 - 10 - 10 + 100 + 75,
+                width: common::DISPLAYWIDTH as u32,
+                height: 100,
+            },
+            text: "To exit fullscreen, just touch anywhere.",
+            size: 50.0,
+        },
+        Element::Button {
+            rect: common::mxcfb_rect {
+                left: (common::DISPLAYWIDTH as u32 - (300 + 50 + 300)) / 2,
+                top: 1400 - 300 - 10 - 10 + 100 + 75 + 75 + 50,
+                width: 300,
+                height: 150,
+            },
+            label: "OK",
+            label_size: 75.0,
+            action: ButtonAction::EnterFullscreen,
+        },
+        Element::Button {
+            rect: common::mxcfb_rect {
+                left: (common::DISPLAYWIDTH as u32 - (300 + 50 + 300)) / 2 + 300 + 50,
+                top: 1400 - 300 - 10 - 10 + 100 + 75 + 75 + 50,
+                width: 300,
+                height: 150,
+            },
+            label: "Back",
+            label_size: 75.0,
+            action: ButtonAction::SwitchLayout(LayoutId::Settings),
+        },
+    ];
+
+    Layout::new(buttons)
+}

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -8,6 +8,7 @@ use libremarkable::framebuffer::{FramebufferDraw, FramebufferIO, FramebufferRefr
 use libremarkable::input::{Finger, InputEvent, MultitouchEvent};
 
 mod confirmexit;
+mod confirmfullscreen;
 mod controls;
 mod keyboard;
 mod settings;
@@ -15,6 +16,7 @@ mod settings;
 pub enum InputOutcome {
     KeyData(KeyData),
     SwitchLayout(LayoutId),
+    EnterFullscreen,
 }
 
 pub struct LayoutManager {
@@ -57,6 +59,7 @@ impl LayoutManager {
         layouts.insert(LayoutId::Settings, settings::create());
         layouts.insert(LayoutId::ConfirmExit, confirmexit::create());
         layouts.insert(LayoutId::Keyboard, keyboard::create());
+        layouts.insert(LayoutId::ConfirmFullscreen, confirmfullscreen::create());
 
         let instance = Self {
             layouts,
@@ -108,6 +111,7 @@ pub enum LayoutId {
     Settings,
     ConfirmExit,
     Keyboard,
+    ConfirmFullscreen,
 }
 
 impl Default for LayoutId {
@@ -282,6 +286,9 @@ impl Layout {
                     ButtonAction::SwitchLayout(layout_id) => {
                         outcomes.push(InputOutcome::SwitchLayout(*layout_id));
                     }
+                    ButtonAction::EnterFullscreen => {
+                        outcomes.push(InputOutcome::EnterFullscreen);
+                    }
                 }
             }
         }
@@ -298,6 +305,7 @@ impl Layout {
 
                     ButtonAction::Function(_) => {}
                     ButtonAction::SwitchLayout(_) => {}
+                    ButtonAction::EnterFullscreen => {}
                 }
             }
         }
@@ -333,4 +341,5 @@ enum ButtonAction {
     DoomKey(u8),
     Function(Box<dyn Fn()>),
     SwitchLayout(LayoutId),
+    EnterFullscreen,
 }

--- a/src/layout/settings.rs
+++ b/src/layout/settings.rs
@@ -51,6 +51,17 @@ pub fn create() -> Layout {
                 width: 400,
                 height: 100,
             },
+            label: "Fullscreen",
+            label_size: 50.0,
+            action: ButtonAction::SwitchLayout(LayoutId::ConfirmFullscreen),
+        },
+        Element::Button {
+            rect: common::mxcfb_rect {
+                left: 62,
+                top: 1400 - 300 - 10 + 100 + 10 + (100 + 10) * 2,
+                width: 400,
+                height: 100,
+            },
             label: "Exit",
             label_size: 50.0,
             action: ButtonAction::SwitchLayout(LayoutId::ConfirmExit),


### PR DESCRIPTION
Adding fullscreen (just landscape without any controls, size is the same for now).

Also noticed that mapping pixels was wrong. I turned 2 grayscale value into one rgb565 which is now how that works. Somehow I never noticed. The approach to map the pixels should not impact performance at all.

Not sure about making fullscreen any larger though. The size is just not enough to justify another dithermap (8x instead of 4x). Scaling the dithered image might work, but would add a lot of extra cpu overhead and the bigger image in general might also hurt performance on top (maybe not on the rM 1, not sure). So not sure if it would be even worth it.

Binary for commit c6761f9276be3fb1ac818720f404280b2ef34bd0: [doomarkable.zip](https://github.com/LinusCDE/doomarkable/files/14068040/doomarkable.zip)

Fullscreen can be accessed from the settings and the user gets informed on how to exit again and that he should have a keyboard present.

@Eeems do you think this would work? I think #2 would be done then.